### PR TITLE
Create ScenarioWidget, Use in ui/snapshot

### DIFF
--- a/playbook/lib/playbook.dart
+++ b/playbook/lib/playbook.dart
@@ -4,4 +4,5 @@ export 'playbook_annotations.dart';
 export 'src/playbook.dart';
 export 'src/scenario.dart';
 export 'src/scenario_layout.dart';
+export 'src/scenario_widget.dart';
 export 'src/story.dart';

--- a/playbook/lib/src/scenario_widget.dart
+++ b/playbook/lib/src/scenario_widget.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import 'scenario.dart';
+
+class ScenarioWidget extends StatelessWidget {
+  const ScenarioWidget({required this.scenario});
+
+  final Scenario scenario;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: scenario.alignment,
+      child: scenario.child,
+    );
+  }
+}

--- a/playbook_snapshot/lib/src/snapshot.dart
+++ b/playbook_snapshot/lib/src/snapshot.dart
@@ -25,7 +25,7 @@ class Snapshot extends TestTool {
 
       for (final story in playbook.stories) {
         for (final scenario in story.scenarios) {
-          final scenarioWidget = builder(scenario.child);
+          final scenarioWidget = builder(ScenarioWidget(scenario: scenario));
 
           testWidgets('Snapshot for ${story.title} ${scenario.title}', (tester) async {
             await SnapshotSupport.startDevice(scenarioWidget, tester, device);

--- a/playbook_ui/lib/src/scenario_container.dart
+++ b/playbook_ui/lib/src/scenario_container.dart
@@ -81,10 +81,7 @@ class ScenarioContainer extends StatelessWidget {
               ),
               body: Theme(
                 data: ThemeProvider.of(context).theme,
-                child: Align(
-                  alignment: scenario.alignment,
-                  child: scenario.child,
-                ),
+                child: ScenarioWidget(scenario: scenario),
               ),
             );
           },


### PR DESCRIPTION
## Overview
- Create `ScenarioWidget` that is simple widget for `Scenario`.
- Use `ScenarioWidget` in `playbook_ui` and `playbook_snapshot`.

## Problem and solution
### Problem
- In `playbook_snapshot` , when component widgets (not full page widget) are taken snapshot, they are expanded to device size and it is not same with `playbook_ui` appearance .

### Solution
- By using `ScenarioWidget` in `playbook_snapshot`, widgets that are taken snapshots are not expanded and same as `playbook_ui`.